### PR TITLE
fix loong64 triplet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,8 +180,8 @@ arch-test-riscv64: riscv64.s
 	riscv64-linux-gnu-ld -z noexecstack -s riscv64.o -o $@
 
 arch-test-loong64: loong64.s
-	loongarch64-linux-gnu-as $^ -o loong64.o
-	loongarch64-linux-gnu-ld -z noexecstack -s loong64.o -o $@
+	loongarch64-linux-gnuf64-as $^ -o loong64.o
+	loongarch64-linux-gnuf64-ld -z noexecstack -s loong64.o -o $@
 
 arch-test-arc: arc.s
 	arc-linux-gnu-as $^ -o arc.o


### PR DESCRIPTION
In LoongArch-toolchain-conventions, should use loongarch64-linux-gnuf64-

https://loongson.github.io/LoongArch-Documentation/LoongArch-toolchain-conventions-EN.html